### PR TITLE
Fix Devise authentication issue in request specs

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -13,19 +13,31 @@ NC='\033[0m' # No Color
 
 echo -e "${GREEN}🚀 Rails RSpec Test Runner${NC}"
 
+# Check if running in Docker or local
+USE_DOCKER=${USE_DOCKER:-true}
+
 # Function to run specific test suite
 run_tests() {
     local test_type=$1
     local path=$2
-    
+
     echo -e "${YELLOW}📦 Running $test_type tests...${NC}"
-    
-    if [ "$test_type" = "all" ]; then
-        bundle exec rspec --format progress
+
+    if [ "$USE_DOCKER" = "true" ]; then
+        echo -e "${YELLOW}🐳 Running tests in Docker container...${NC}"
+        if [ "$test_type" = "all" ]; then
+            docker-compose exec app bash -c "RAILS_ENV=test bundle exec rspec --format progress"
+        else
+            docker-compose exec app bash -c "RAILS_ENV=test bundle exec rspec $path --format progress"
+        fi
     else
-        bundle exec rspec $path --format progress
+        if [ "$test_type" = "all" ]; then
+            bundle exec rspec --format progress
+        else
+            bundle exec rspec $path --format progress
+        fi
     fi
-    
+
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ $test_type tests passed!${NC}"
     else
@@ -47,11 +59,19 @@ case "${1:-all}" in
         ;;
     "parallel")
         echo -e "${YELLOW}⚡ Running parallel tests...${NC}"
-        bundle exec parallel_rspec spec/ --combine-stderr --serialize-stdout
+        if [ "$USE_DOCKER" = "true" ]; then
+            docker-compose exec app bash -c "RAILS_ENV=test bundle exec parallel_rspec spec/ --combine-stderr --serialize-stdout"
+        else
+            bundle exec parallel_rspec spec/ --combine-stderr --serialize-stdout
+        fi
         ;;
     "coverage")
         echo -e "${YELLOW}📊 Running tests with coverage...${NC}"
-        COVERAGE=true bundle exec rspec --format progress
+        if [ "$USE_DOCKER" = "true" ]; then
+            docker-compose exec app bash -c "RAILS_ENV=test COVERAGE=true bundle exec rspec --format progress"
+        else
+            COVERAGE=true bundle exec rspec --format progress
+        fi
         ;;
     "all")
         run_tests "All" ""

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "user@example.com" }
+    sequence(:email) { |n| "user#{n}@example.com" }
     password { "password123" }
     password_confirmation { "password123" }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,6 +97,18 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :feature
+
+  # Include Warden test helpers for request specs
+  config.include Warden::Test::Helpers
+
+  # Include route helpers
+  config.include Rails.application.routes.url_helpers
+
+  # Reset Warden after each test
+  config.after :each do
+    Warden.test_reset!
+  end
 
   # Include Rails controller testing helpers
   config.include Rails::Controller::Testing::TestProcess, type: :controller

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -25,11 +25,9 @@ RSpec.describe "Home", type: :request do
   context "when user is signed in" do
     let(:user) { create(:user) }
 
-    before do
-      sign_in user
-    end
-
     it "still shows the landing page" do
+      # Use Warden's login_as for request specs
+      login_as(user, scope: :user)
       get root_path
       expect(response).to have_http_status(:success)
       expect(response.body).to include("PROXYFIELD")


### PR DESCRIPTION
- Update test runner to support Docker execution
- Fix user factory to use sequential emails
- Replace Devise sign_in with Warden login_as in request specs
- Add Warden test helpers to rails_helper
- Include route helpers for request specs

This resolves the 'Could not find a valid mapping' error when authenticating users in request tests.